### PR TITLE
Fix escapes inside pre for MarkdownV2

### DIFF
--- a/demo/entitiesDecodePreTest.php
+++ b/demo/entitiesDecodePreTest.php
@@ -1,0 +1,68 @@
+<?php
+
+include '../src/EntityDecoder.php';
+
+use lucadevelop\TelegramEntitiesDecoder\EntityDecoder;
+
+$telegramUpdateExample = '
+{
+    "update_id": 123456789,
+    "message": {
+        "message_id": 1234,
+        "from": {
+            "id": 123456789,
+            "is_bot": false,
+            "first_name": "First Name",
+            "username": "UserName",
+            "language_code": "en"
+        },
+        "chat": {
+            "id": 123456789,
+            "first_name": "First Name",
+            "username": "UserName",
+            "type": "private"
+        },
+        "date": 1729790164,
+        "text": "Quoted message\\nTest message. Bold. Italic. Underline. Mono. \\\\Slash.\\nconsole.log(\'Test message. `\\"```test` \\\\Slash\');",
+        "entities": [
+            {
+                "offset": 0,
+                "length": 14,
+                "type": "blockquote"
+            },
+            {
+                "offset": 29,
+                "length": 4,
+                "type": "bold"
+            },
+            {
+                "offset": 35,
+                "length": 6,
+                "type": "italic"
+            },
+            {
+                "offset": 43,
+                "length": 9,
+                "type": "underline"
+            },
+            {
+                "offset": 54,
+                "length": 4,
+                "type": "code"
+            },
+            {
+                "offset": 68,
+                "length": 47,
+                "type": "pre",
+                "language": "javascript"
+            }
+        ]
+    }
+}';
+
+$updateObj = json_decode($telegramUpdateExample);
+
+$entity_decoder = new EntityDecoder('MarkdownV2');
+$decoded_text = $entity_decoder->decode($updateObj->message);
+
+var_export($decoded_text);

--- a/src/EntityDecoder.php
+++ b/src/EntityDecoder.php
@@ -304,7 +304,7 @@ class EntityDecoder
      * Apply Telegram escape rules for the choosen style
      */
     protected function escapeSpecialChars($char, $isEntityOpen, $entities) {
-        if ($this->style == 'Markdown')
+        if ($this->style === 'Markdown')
         {
             if ($isEntityOpen)
             {
@@ -337,27 +337,36 @@ class EntityDecoder
                 }
             }
         }
-        else if ($this->style == 'HTML')
+        else if ($this->style === 'HTML')
         {
             return ($char == '<' ? '&lt;' : ($char == '>' ? '&gt;' : ($char == '&' ? '&amp;' : $char)));
         }
-        else if ($this->style == 'MarkdownV2')
+        else if ($this->style === 'MarkdownV2')
         {
             $isBlockquoteOpen = false;
+            $isPreOpen = false;
+
             foreach ($entities as $entity) {
-                if ($entity->type === 'blockquote') {
-                    $isBlockquoteOpen = true;
-                    break;
+                switch ($entity->type) {
+                    case 'blockquote':
+                        $isBlockquoteOpen = true;
+                        break;
+
+                    case 'pre':
+                        $isPreOpen = true;
+                        break;
                 }
             }
-            if($isBlockquoteOpen && $char == "\n")
-            {
+
+            if ($isBlockquoteOpen && $char === "\n") {
                 return $char.'>';
             }
-            else
-            {
-                return (in_array($char, ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '\\']) ? '\\'.$char : $char);
+
+            if ($isPreOpen) {
+                return (in_array($char, ['`', '\\']) ? '\\' . $char : $char);
             }
+
+            return (in_array($char, ['_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!', '\\']) ? '\\'.$char : $char);
         }
         else
         {


### PR DESCRIPTION
Fix escapes inside `pre` for MarkdownV2